### PR TITLE
修复喵喵插件更新运行依赖步骤错误

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,7 +65,8 @@ if [ -d $MIAO_PLUGIN_PATH"/.git" ]; then
     if [[ ! -f "$HOME/.ovo/miao.ok" ]]; then
         set -e
         echo -e "\n ================ \n ${Info} ${GreenBG} 更新 喵喵插件 运行依赖 ${Font} \n ================ \n"
-        pnpm add image-size -w
+        cd $WORK_DIR
+        pnpm install -P
         touch ~/.ovo/miao.ok
         set +e
     fi


### PR DESCRIPTION
最近更新后一次运行时出现报错:
ERR_PNPM_INCLUDED_DEPS_CONFLICT  modules directory (at "/app/Yunzai-Bot") was installed with optionalDependencies, dependencies. Current install wants optionalDependencies, dependencies, devDependencies.

排查发现是喵喵插件在3.8的提交 [调整部分模块的引用方式](https://github.com/yoimiya-kokomi/miao-plugin/commit/29e1c446a748ce498264fa062f3f8f520eff80bc) 中, 去掉了`pnpm add image-size -w`。

因此对entrypoint.sh做了同样的变更，按照插件中建议的方式改成了`pnpm install -P`, 不过感觉这段完全去掉应该也没有关系...