### PR TITLE
fix: pnpm conflict

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,7 +65,6 @@ if [ -d $MIAO_PLUGIN_PATH"/.git" ]; then
     if [[ ! -f "$HOME/.ovo/miao.ok" ]]; then
         set -e
         echo -e "\n ================ \n ${Info} ${GreenBG} 更新 喵喵插件 运行依赖 ${Font} \n ================ \n"
-        cd $WORK_DIR
         pnpm install -P
         touch ~/.ovo/miao.ok
         set +e
@@ -95,7 +94,7 @@ if [ -d $PY_PLUGIN_PATH"/.git" ]; then
     if [[ ! -f "$HOME/.ovo/py.ok" ]]; then
         set -e
         echo -e "\n ================ \n ${Info} ${GreenBG} 更新 py-plugin 运行依赖 ${Font} \n ================ \n"
-        pnpm install iconv-lite @grpc/grpc-js @grpc/proto-loader -w
+        pnpm install -P
         poetry config virtualenvs.in-project true
         poetry install
         touch ~/.ovo/py.ok
@@ -127,7 +126,7 @@ if [ -d $XIAOYAO_CVS_PATH"/.git" ]; then
     if [[ ! -f "$HOME/.ovo/xiaoyao.ok" ]]; then
         set -e
         echo -e "\n ================ \n ${Info} ${GreenBG} 更新 xiaoyao-cvs 插件运行依赖 ${Font} \n ================ \n"
-        pnpm add promise-retry superagent -w
+        pnpm install -P
         touch ~/.ovo/xiaoyao.ok
         set +e
     fi
@@ -156,7 +155,7 @@ if [ -d $GUOBA_PLUGIN_PATH"/.git" ]; then
     if [[ ! -f "$HOME/.ovo/guoba.ok" ]]; then
         set -e
         echo -e "\n ================ \n ${Info} ${GreenBG} 更新 Guoba-Plugin 插件运行依赖 ${Font} \n ================ \n"
-        pnpm add multer body-parser jsonwebtoken -w
+        pnpm install -P
         touch ~/.ovo/guoba.ok
         set +e
     fi


### PR DESCRIPTION
和上一个PR类似，最近拉取最新镜像后报错：
```
ERR_PNPM_INCLUDED_DEPS_CONFLICT  modules directory (at "/app/Yunzai-Bot") was installed with optionalDependencies, dependencies. Current install wants optionalDependencies, dependencies, devDependencies.
```
发现其他插件py-plugin和xiaoyao-cvs-plugin通过原来的指令拉取依赖会报同样的错，需通过`pnpm install -P`指令拉取依赖，虽然xiaoyao-cvs-plugin应该不需要拉依赖，但是以防万一还是加上了，Guoba-Plugin倒是没测，但是应该类似，对entrypoint.sh进行了一些修改。

顺便一提，之前的PR只合并到main分支，没有更新到v3plus等其他分支，导致镜像还是之前的版本，辛苦同步更改一下其他分支发版下。